### PR TITLE
👨🏻‍💻 👏 Fixed up contact picker for Xcode 10

### DIFF
--- a/Source/Extensions/String+Extensions.swift
+++ b/Source/Extensions/String+Extensions.swift
@@ -12,8 +12,9 @@ extension String {
     
     subscript (r: Range<Int>) -> String {
         let start = index(startIndex, offsetBy: r.lowerBound)
-        let end = index(startIndex, offsetBy: r.upperBound)
-        return String(self[Range(start ..< end)])
+        let end = index(startIndex, offsetBy: min(r.upperBound, self.count))
+        let range: Range<Index> = start..<end
+        return String(self[range])
     }
     
     var containsAlphabets: Bool {

--- a/Source/Extensions/UIView+Extensions.swift
+++ b/Source/Extensions/UIView+Extensions.swift
@@ -24,7 +24,7 @@ extension UIView {
             return layer.cornerRadius
         }
         set {
-            layer.cornerRadius = circleCorner ? min(bounds.size.height, bounds.size.width) / 2 : newValue
+            layer.cornerRadius = newValue
                 //abs(CGFloat(Int(newValue * 100)) / 100)
         }
     }

--- a/Source/Extensions/UIView+Extensions.swift
+++ b/Source/Extensions/UIView+Extensions.swift
@@ -6,7 +6,7 @@ import Foundation
 @IBDesignable
 extension UIView {
     
-    @IBInspectable
+//    @IBInspectable
     /// Should the corner be as circle
     public var circleCorner: Bool {
         get {
@@ -17,7 +17,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Corner radius of view; also inspectable from Storyboard.
     public var cornerRadius: CGFloat {
         get {
@@ -29,7 +29,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Border color of view; also inspectable from Storyboard.
     public var borderColor: UIColor? {
         get {
@@ -47,7 +47,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Border width of view; also inspectable from Storyboard.
     public var borderWidth: CGFloat {
         get {
@@ -58,7 +58,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Shadow color of view; also inspectable from Storyboard.
     public var shadowColor: UIColor? {
         get {
@@ -72,7 +72,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Shadow offset of view; also inspectable from Storyboard.
     public var shadowOffset: CGSize {
         get {
@@ -83,7 +83,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Shadow opacity of view; also inspectable from Storyboard.
     public var shadowOpacity: Double {
         get {
@@ -94,7 +94,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Shadow radius of view; also inspectable from Storyboard.
     public var shadowRadius: CGFloat {
         get {
@@ -105,7 +105,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Shadow path of view; also inspectable from Storyboard.
     public var shadowPath: CGPath? {
         get {
@@ -116,7 +116,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Should shadow rasterize of view; also inspectable from Storyboard.
     /// cache the rendered shadow so that it doesn't need to be redrawn
     public var shadowShouldRasterize: Bool {
@@ -128,7 +128,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Should shadow rasterize of view; also inspectable from Storyboard.
     /// cache the rendered shadow so that it doesn't need to be redrawn
     public var shadowRasterizationScale: CGFloat {
@@ -140,7 +140,7 @@ extension UIView {
         }
     }
     
-    @IBInspectable
+//    @IBInspectable
     /// Corner radius of view; also inspectable from Storyboard.
     public var maskToBounds: Bool {
         get {

--- a/Source/Pickers/Contacts/Views/ContactCell.swift
+++ b/Source/Pickers/Contacts/Views/ContactCell.swift
@@ -5,8 +5,7 @@ final class ContactTableViewCell: UITableViewCell {
     // MARK: Properties
     
     static let identifier = String(describing: ContactTableViewCell.self)
-    static let size: CGSize = CGSize(width: 80, height: 80)
-    
+
     var contact: Contact?
     
     // MARK: Initialize
@@ -46,6 +45,9 @@ final class ContactTableViewCell: UITableViewCell {
     func update() {
         guard let contact = contact else { return }
         
+        let value: CGFloat = self.contentView.height - 8
+        imageView?.size = CGSize(width: value, height: value)
+
         if let ava = contact.image {
             imageView?.image = ava
         } else {


### PR DESCRIPTION
Summary:
- String extension would crash on empty contact name
   -  [✅]`subscript` will take `min(length | upperBound)`
- `UIGraphicsGetCurrentContext` would fail to get current context for `CGZise.zero`
   - [✅] Give it a size



![ezgif-4-e000ab6e6cf6](https://user-images.githubusercontent.com/2506034/47257621-379f4800-d45e-11e8-925d-cd3373921988.gif)
edit: updated screenshot

