### PR TITLE
Update String+Extensions.swift

### DIFF
--- a/Source/Extensions/String+Extensions.swift
+++ b/Source/Extensions/String+Extensions.swift
@@ -13,7 +13,7 @@ extension String {
     subscript (r: Range<Int>) -> String {
         let start = index(startIndex, offsetBy: r.lowerBound)
         let end = index(startIndex, offsetBy: r.upperBound)
-        return String(self[Range(start ..< end)])
+        return String(self[start ..< end])
     }
     
     var containsAlphabets: Bool {


### PR DESCRIPTION
fixing a bug 
> Referencing initializer 'init(_:)' on 'Range' requires that 'String.Index' conform to 'Strideable'


referencing about this issue:
https://www.reddit.com/r/swift/comments/bbrmug/range_not_meeting_signedinteger_strideable/
